### PR TITLE
Load subr-x for using string-empty-p

### DIFF
--- a/panda.el
+++ b/panda.el
@@ -34,6 +34,7 @@
 (require 'cl-lib)
 (require 'url)
 (require 'browse-url)
+(require 'subr-x)
 
 (defgroup panda nil
   "Client for Bamboo's REST API."


### PR DESCRIPTION
And fix following byte-compile warning

```
panda.el:978:1:Warning: the function ‘string-empty-p’ is not known to be
    defined.
```